### PR TITLE
fix example: add correct labels

### DIFF
--- a/examples/nginx.controller.json
+++ b/examples/nginx.controller.json
@@ -4,6 +4,7 @@
   "metadata":{
     "name":"nginx",
     "labels":{
+      "visualize":"true",
       "name":"nginx"
     }
   },
@@ -15,6 +16,7 @@
     "template":{
       "metadata":{
         "labels":{
+          "visualize":"true",
           "name":"nginx",
           "app": "sample",
           "version": "0.0.1",

--- a/examples/nginx.service.json
+++ b/examples/nginx.service.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "nginx",
     "labels": {
+      "visualize":"true",
       "name": "nginx",
       "app": "sample"
     }


### PR DESCRIPTION
The api calls, that are used, ask for the "visualize" label, see:

  "...?labelSelector=visualize%3Dtrue"

With this patch starting the proxy like:

  kubectl proxy --www=gcp-live-k8s-visualizer/ --www-prefix=/ --api-prefix=/api/

works perfectly.

!!! Thanks for your great talk @fosdem2016
